### PR TITLE
protect and alert on missing integration flag

### DIFF
--- a/.changes/unreleased/Fixed-20241216-125634.yaml
+++ b/.changes/unreleased/Fixed-20241216-125634.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: If no --integration flag is given present the user with an error
+time: 2024-12-16T12:56:34.444366-06:00

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,9 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cluster := viper.GetString("cluster")
 		integration := viper.GetString("integration")
+		if integration == "" {
+			cobra.CheckErr(fmt.Errorf("--integration was not given please specify the ID or Alias of the kubernetes integration to send the events too"))
+		}
 		configuration, err := LoadConfig()
 		cobra.CheckErr(err)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,7 @@ var rootCmd = &cobra.Command{
 		cluster := viper.GetString("cluster")
 		integration := viper.GetString("integration")
 		if integration == "" {
-			cobra.CheckErr(fmt.Errorf("--integration was not given please specify the ID or Alias of the kubernetes integration to send the events too"))
+			cobra.CheckErr(fmt.Errorf("--integration was not given, please specify the ID or Alias of the kubernetes integration to send the events too"))
 		}
 		configuration, err := LoadConfig()
 		cobra.CheckErr(err)


### PR DESCRIPTION
Resolves #

### Problem

```
I forgot to specify --integration flag entirely, so it sent all of the payloads for the integration alias of an empty string - the server rejected these with an error, but the agent didn't fail or log anything or give any hint that something was wrong
```

### Solution

Add a catch for this and report to the user what do to

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change