### PR TITLE
Breaking change for unification

### DIFF
--- a/.changes/unreleased/Refactor-20250812-152151.yaml
+++ b/.changes/unreleased/Refactor-20250812-152151.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: 'BREAKING CHANGE: Refactor the automatic external_kind calculation for when posting to custom data integration so that "/" are not turned into "_"'
+time: 2025-08-12T15:21:51.825057-04:00

--- a/workers/k8s.go
+++ b/workers/k8s.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -75,12 +76,11 @@ func (s *K8SWorker) parse(item *unstructured.Unstructured) (opslevel.JSON, error
 }
 
 func (s *K8SWorker) sendEvent(kind string, id string, value *unstructured.Unstructured) {
-	kind = strings.Replace(kind, "/", "_", -1)
 	if viper.GetBool("dry-run") {
 		log.Info().Msgf("[DRYRUN] POST %s | %s", kind, id)
 		log.Debug().Msgf("\t%#v", value)
 	} else {
-		url := fmt.Sprintf("%s?external_kind=%s", s.integration, kind)
+		url := fmt.Sprintf("%s?external_kind=%s", s.integration, url.QueryEscape(kind))
 		resp, err := s.restClient.R().SetBody(value).Post(url)
 		if err != nil {
 			log.Error().Err(err).Msgf("error during post")


### PR DESCRIPTION
Resolves #

### Problem

Previously the external kind were being calculated differently for when the agent sent to the custom data integration

`apps_v1_Deployment` vs `apps/v1/Deployment`

### Solution

Unify this to use the same external kind's between the turnkey integration and the custom data integration

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
    - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change