### PR TITLE
Add grype security scanning workflow

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -13,4 +13,6 @@ jobs:
     uses: opslevel/actions/.github/workflows/grype.yml@main
     with:
       alias: opslevel_agent
-    secrets: inherit
+    secrets:
+      ORG_GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+      GRYPE_INTEGRATION_SECRET: ${{ secrets.GRYPE_INTEGRATION_SECRET }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,13 @@
+name: Security
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 13 * * 1"  # 8am CT on Mondays
+
+jobs:
+  call-grype:
+    uses: opslevel/actions/.github/workflows/grype.yml@main
+    with:
+      alias: opslevel_agent
+    secrets: inherit

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 13 * * 1"  # 8am CT on Mondays
 
+permissions:
+  contents: read
+
 jobs:
   call-grype:
     uses: opslevel/actions/.github/workflows/grype.yml@main


### PR DESCRIPTION
Adds a weekly Grype vulnerability scanning workflow, equivalent to what was added in OpsLevel/jenkins-opslevel-plugin#123.

The workflow runs every Monday at 8am CT and can also be triggered manually via `workflow_dispatch`. It calls the shared `opslevel/actions/.github/workflows/grype.yml` reusable workflow.

Adding this because the check data is stale: https://app.opslevel.com/components/opslevel_agent/maturity-report?checkId=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpHZW5lcmljLzI4ODU3